### PR TITLE
Updating Queries to accomodate the new database design

### DIFF
--- a/src/main/java/com/cbms/app/ModelController.java
+++ b/src/main/java/com/cbms/app/ModelController.java
@@ -35,7 +35,7 @@ public class ModelController {
 
     private ModelController() throws Exception {
         db = new Database();
-        trainingSets = db.getTrainDatasets();
+        //trainingSets = db.getTrainDatasets();
         instancesSets = new TreeMap<>();
         reducedInstancesSets = new TreeMap<>();
         classifierSets = new TreeMap<>();
@@ -95,7 +95,7 @@ public class ModelController {
      */
     public ArrayList<Asset> estimate() throws Exception {
 
-        ArrayList<Asset> assets = db.getAssetsFromDatasetID(2);
+        ArrayList<Asset> assets = db.getAssetsFromAssetTypeID(1);
         assets = estimateRUL(assets, "FD001");
 
         return assets;

--- a/src/main/java/com/cbms/source/local/Database.java
+++ b/src/main/java/com/cbms/source/local/Database.java
@@ -2,8 +2,8 @@
   This object will hold all the queries that we are making to the database
 
   @author Paul Micu
-  @version 1.0
-  @last_edit 11/08/2020
+  @version 1.1
+  @last_edit 12/05/2020
  */
 package com.cbms.source.local;
 
@@ -19,7 +19,6 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.text.ParseException;
 import java.util.ArrayList;
 
 public class Database {
@@ -34,7 +33,7 @@ public class Database {
      * and return the corresponding ResultSet.
      *
      * @author Paul Micu
-     * */
+     */
     public ResultSet executeQuery(String query) {
         ResultSet dataRS = null;
         try {
@@ -44,32 +43,38 @@ public class Database {
             dataRS = stmt.executeQuery(query);
 
 
-        } catch (SQLException throwables) {
-            throwables.printStackTrace();
+        } catch (SQLException throwable) {
+            throwable.printStackTrace();
         }
         return dataRS;
     }
 
-    /** This will return an arrayList containing all the dataset_id of the datasets with a train tag
+    /**
+     * This will return an arrayList containing all the asset type IDs of the assets that
+     * have train data. Meaning that the archived tag is set to 0 (train data instead of
+     * test data).
      *
      * @author Paul Micu
      * */
-//    public ArrayList<Integer> getTrainDatasets() throws SQLException {
-//        ArrayList<Integer> datasets = new ArrayList<>();
-//        ResultSet datasetQuery = executeQuery("select dataset_id from cbms.dataset where train=1");
-//        while (datasetQuery.next())
-//            datasets.add(datasetQuery.getInt("dataset_id"));
-//        return datasets;
-//    }
+    public ArrayList<Integer> getTrainAssetTypes() throws SQLException {
+        ArrayList<Integer> assetTypes = new ArrayList<>();
+        ResultSet assetTypeQuery = executeQuery("SELECT DISTINCT a.asset_type_id FROM cbms.asset a WHERE a.archived = 0");
+        while (assetTypeQuery.next())
+            assetTypes.add(assetTypeQuery.getInt("asset_type_id"));
+        return assetTypes;
+    }
 
-    /** When given a dataset_id, this will return an arraylist of Assets containing all of the assets in that dataset
-     * the asset object will also contain a reference to all the asset attributes(sensors) and all their measurements
+    /**
+     * When given an asset type ID, this will return an arraylist of Assets containing all of
+     * the assets of that asset type. The asset object will also contain a reference to all the
+     * asset attributes(sensors) and all their measurements. The method also allows to choose to
+     * return an arraylist of the train assets (1) or test assets (0) with the archived parameter.
      *
      * @author Paul Micu
-     * */
-    public ArrayList<Asset> getAssetsFromAssetTypeID(int assetTypeID) throws SQLException {
+     */
+    public ArrayList<Asset> getAssetsFromAssetTypeID(int assetTypeID, int archived) throws SQLException {
         ArrayList<Asset> assets = new ArrayList<>();
-        ResultSet assetsQuery = executeQuery("SELECT a.asset_id, a.asset_type_id, a.sn, a.location,a.description FROM asset a WHERE a.asset_type_id = " + assetTypeID);
+        ResultSet assetsQuery = executeQuery("SELECT a.asset_id, a.asset_type_id, a.sn, a.location,a.description FROM asset a WHERE a.archived =" + archived + " AND a.asset_type_id = " + assetTypeID);
 
         while (assetsQuery.next()) {
             Asset newAsset = new Asset();
@@ -79,7 +84,7 @@ public class Database {
             newAsset.setLocation(assetsQuery.getString("location"));
             newAsset.setSerialNo(assetsQuery.getString("sn"));
             AssetInfo newAssetInfo = new AssetInfo();
-            ResultSet attributesQuery = executeQuery("SELECT * FROM attribute_measurements am, attribute att WHERE att.attribute_id=am.attribute_id and  am.asset_id = " + newAsset.getId());
+            ResultSet attributesQuery = executeQuery("SELECT * FROM attribute_measurements am, attribute att WHERE att.attribute_id=am.attribute_id AND am.asset_id = " + newAsset.getId());
             int previousAttributeID = 1;
             String previousAttributeName = "";
             AssetAttribute newAttribute = new AssetAttribute();
@@ -105,10 +110,11 @@ public class Database {
         return assets;
     }
 
-    /** When given an asset_id, this will return an Asset object containing a reference to all the asset attributes(sensors) and all their measurements
+    /**
+     * When given an asset_id, this will return an Asset object containing a reference to all the asset attributes(sensors) and all their measurements.
      *
      * @author Paul Micu
-     * */
+     */
     public Asset getAssetsFromAssetID(int assetID) throws SQLException {
         ResultSet assetsQuery = executeQuery("SELECT a.asset_id, a.asset_type_id, a.sn, a.location,a.description FROM asset a WHERE a.asset_id=" + assetID);
         Asset newAsset = new Asset();
@@ -119,7 +125,7 @@ public class Database {
             newAsset.setLocation(assetsQuery.getString("location"));
             newAsset.setSerialNo(assetsQuery.getString("sn"));
             AssetInfo newAssetInfo = new AssetInfo();
-            ResultSet attributesQuery = executeQuery("SELECT * FROM attribute_measurements am, attribute att WHERE att.attribute_id=am.attribute_id and  am.asset_id = " + newAsset.getId());
+            ResultSet attributesQuery = executeQuery("SELECT * FROM attribute_measurements am, attribute att WHERE att.attribute_id=am.attribute_id AND am.asset_id = " + newAsset.getId());
             int previousAttributeID = 1;
             String previousAttributeName = "";
             AssetAttribute newAttribute = new AssetAttribute();
@@ -140,109 +146,112 @@ public class Database {
             }
             newAsset.setAssetInfo(newAssetInfo);
 
-
         }
         return newAsset;
     }
 
-    /** when given an asset_id, this will query the database for that asset and create an instance object
+    /**
+     * when given an asset_id, this will query the database for that asset and create an instance object.
      *
      * @author Paul Micu
-     * */
+     */
     public Instances createInstanceFromAssetID(int assetID) throws SQLException {
-        FastVector atts;
+        FastVector attributesVector;
         Instances data;
-        double[] vals;
-        String datasetName = Integer.toString(assetID);
+        double[] values;
+        String assetName = Integer.toString(assetID);
         Asset asset = getAssetsFromAssetID(assetID);
         ArrayList<String> attributeNames = getAttributesNameFromAssetID(assetID);
 
-
         // 1. set up attributes
-        atts = new FastVector();
+        attributesVector = new FastVector();
         // - numeric
-        atts.addElement(new Attribute("Asset_id"));
-        atts.addElement(new Attribute("Time_Cycle"));
+        attributesVector.addElement(new Attribute("Asset_id"));
+        attributesVector.addElement(new Attribute("Time_Cycle"));
         for (String attributeName : attributeNames) {
-            atts.addElement(new Attribute(attributeName));
+            attributesVector.addElement(new Attribute(attributeName));
         }
         // 2. create Instances object
-        data = new Instances(datasetName, atts, 0);
+        data = new Instances(assetName, attributesVector, 0);
 
         for (int timeCycle = 1; timeCycle <= asset.getAssetInfo().getLastRecorderTimeCycle(); timeCycle++) {
-            vals = new double[data.numAttributes()];
-            vals[0] = asset.getId();
-            vals[1] = timeCycle;
+            values = new double[data.numAttributes()];
+            values[0] = asset.getId();
+            values[1] = timeCycle;
             for (int i = 0; i < asset.getAssetInfo().getAssetAttributes().size(); i++) {
-                vals[i + 2] = asset.getAssetInfo().getAssetAttributes().get(i).getMeasurements(timeCycle);
+                values[i + 2] = asset.getAssetInfo().getAssetAttributes().get(i).getMeasurements(timeCycle);
             }
-            data.add(new Instance(1.0, vals));
+            data.add(new Instance(1.0, values));
         }
 
         return data;
     }
 
-    /** when given an dataset_id, this will query the database for that asset and create an instance object
-     * containing all the assets that are part of that dataset
+    /**
+     * When given an asset type ID, this will query the database for that asset type
+     * and create an instance object containing all the assets that are of that asset type.
+     * Additionally, the method also allows to choose to return an arraylist of the train
+     * assets (1) or test assets (0) with the archived parameter.
      *
      * @author Paul Micu
-     * */
-    public Instances createInstances(int datasetID) throws ParseException, SQLException {
-        FastVector atts;
+     */
+    public Instances createInstancesFromAssetTypeID(int assetTypeID, int archived) throws SQLException {
+        FastVector attributesVector;
         Instances data;
-        double[] vals;
-        String datasetName = getDatasetNameFromID(datasetID);
-        ArrayList<Asset> assets = getAssetsFromAssetTypeID(datasetID);
-        ArrayList<String> attributeNames = getAttributesNameFromDatasetID(datasetID);
-
+        double[] values;
+        String assetTypeName = getAssetTypeNameFromID(assetTypeID);
+        ArrayList<Asset> assets = getAssetsFromAssetTypeID(assetTypeID, archived);
+        ArrayList<String> attributeNames = getAttributesNameFromAssetTypeID(assetTypeID);
 
         // 1. set up attributes
-        atts = new FastVector();
+        attributesVector = new FastVector();
         // - numeric
-        atts.addElement(new Attribute("Asset_id"));
-        atts.addElement(new Attribute("Time_Cycle"));
+        attributesVector.addElement(new Attribute("Asset_id"));
+        attributesVector.addElement(new Attribute("Time_Cycle"));
         for (String attributeName : attributeNames) {
-            atts.addElement(new Attribute(attributeName));
+            attributesVector.addElement(new Attribute(attributeName));
         }
         // 2. create Instances object
-        data = new Instances(datasetName, atts, 0);
+        data = new Instances(assetTypeName, attributesVector, 0);
 
         for (Asset asset : assets) {
             for (int timeCycle = 1; timeCycle <= asset.getAssetInfo().getLastRecorderTimeCycle(); timeCycle++) {
-                vals = new double[data.numAttributes()];
-                vals[0] = asset.getId();
-                vals[1] = timeCycle;
+                values = new double[data.numAttributes()];
+                values[0] = asset.getId();
+                values[1] = timeCycle;
                 for (int i = 0; i < asset.getAssetInfo().getAssetAttributes().size(); i++) {
-                    vals[i + 2] = asset.getAssetInfo().getAssetAttributes().get(i).getMeasurements(timeCycle);
+                    values[i + 2] = asset.getAssetInfo().getAssetAttributes().get(i).getMeasurements(timeCycle);
                 }
-                data.add(new Instance(1.0, vals));
+                data.add(new Instance(1.0, values));
             }
         }
         return data;
     }
 
-    /** When given an dataset_id this will return an arraylist of all the attributes name that the assets in that dataset have
+    /**
+     * When given an asset type ID, this will return an arraylist of all the attribute's names
+     * that the assets of that type contain.
      *
      * @author Paul Micu
-     * */
-    private ArrayList<String> getAttributesNameFromDatasetID(int datasetID) throws SQLException {
+     */
+    private ArrayList<String> getAttributesNameFromAssetTypeID(int assetTypeID) throws SQLException {
         ArrayList<String> attributeNames = new ArrayList<>();
-        String query = "SELECT DISTINCT att.attribute_name FROM attribute att, attribute_measurements am, asset a, dataset_asset_assoc daa\n" +
-                "WHERE daa.dataset_id=" + datasetID + " AND \n" +
-                "daa.asset_id = a.asset_id AND\n" +
+        String query = "SELECT DISTINCT att.attribute_name FROM attribute att, attribute_measurements am, asset a\n" +
+                "WHERE a.asset_type_ID = " + assetTypeID + " AND \n" +
                 "am.asset_id = a.asset_id AND\n" +
                 "att.attribute_id = am.attribute_id " +
-                "order by att.attribute_id";
+                "ORDER by att.attribute_id";
         ResultSet queryResult = executeQuery(query);
         while (queryResult.next())
             attributeNames.add(queryResult.getString("attribute_name"));
         return attributeNames;
     }
 
-    /** When given an asset_id this will return an arraylist of all the attributes name that specific asset has
+    /**
+     * When given an asset_id, this will return an arraylist of all that asset attribute's names.
      *
      * @author Paul Micu
-     * */
+     */
     private ArrayList<String> getAttributesNameFromAssetID(int assetID) throws SQLException {
         ArrayList<String> attributeNames = new ArrayList<>();
         String query = "SELECT DISTINCT att.attribute_name FROM attribute att, attribute_measurements am, asset a WHERE a.asset_id=" + assetID + " AND am.asset_id = a.asset_id AND att.attribute_id = am.attribute_id order by att.attribute_id";
@@ -252,13 +261,14 @@ public class Database {
         return attributeNames;
     }
 
-    /** When given an dataset_id this will return the name of the dataset
+    /**
+     * When given an asset type ID, this will return the asset type Name.
      *
      * @author Paul Micu
-     * */
-    public String getDatasetNameFromID(int datasetID) throws SQLException {
+     */
+    public String getAssetTypeNameFromID(int assetTypeID) throws SQLException {
         String name = "null";
-        String query = "select dataset.name from dataset where dataset_id=" + datasetID;
+        String query = "SELECT at.name FROM asset_type at WHERE at.asset_type_id = " + assetTypeID;
         ResultSet queryResult = executeQuery(query);
         if (queryResult.next())
             name = queryResult.getString("name");
@@ -266,33 +276,32 @@ public class Database {
     }
 
     /**
-     * When given and an asset_id and an rul estimate, this will add the corresponfing entry in the asset_model_calculation table
-     * this only works for Linear regression model
+     * When given an asset_id and an rul estimate, this will add the corresponding entry in
+     * the asset_model_calculation table. This only works for Linear regression model.
      *
      * @author Paul Micu
-     * */
+     */
     public void addRULEstimate(int id, double estimate) {
-        String query = "insert into asset_model_calculation values(" + id + ",1,now()," + estimate + ")";
+        String query = "INSERT INTO asset_model_calculation values(" + id + ",1,now()," + estimate + ")";
         executeQuery(query);
     }
 
     /**
      * When given an asset ID this will delete the the asset from the database as well as the corresponding
      * tables that reference the asset ID
-     * @param id
+     *
+     * @param assetID represents the asset's ID
      */
-    public void deleteAssetByID(int id) {
-        String query = "DELETE FROM attribute_measurements WHERE asset_id = " + id;
+    public void deleteAssetByID(int assetID) {
+        String query = "DELETE FROM attribute_measurements WHERE asset_id = " + assetID;
         executeQuery(query);
-        query = "DELETE FROM asset_model_calculation WHERE asset_id = " + id;
+        query = "DELETE FROM asset_model_calculation WHERE asset_id = " + assetID;
         executeQuery(query);
-        query = "DELETE FROM dataset_asset_assoc WHERE asset_id = " + id;
-        executeQuery(query);
-        query = "DELETE FROM asset WHERE asset_id = " + id;
+        query = "DELETE FROM asset WHERE asset_id = " + assetID;
         executeQuery(query);
     }
-  
-    /** 
+
+    /**
      * Stops the connection to the database
      *
      * @author Najim

--- a/src/main/java/com/cbms/source/local/Database.java
+++ b/src/main/java/com/cbms/source/local/Database.java
@@ -54,22 +54,22 @@ public class Database {
      *
      * @author Paul Micu
      * */
-    public ArrayList<Integer> getTrainDatasets() throws SQLException {
-        ArrayList<Integer> datasets = new ArrayList<>();
-        ResultSet datasetQuery = executeQuery("select dataset_id from cbms.dataset where train=1");
-        while (datasetQuery.next())
-            datasets.add(datasetQuery.getInt("dataset_id"));
-        return datasets;
-    }
+//    public ArrayList<Integer> getTrainDatasets() throws SQLException {
+//        ArrayList<Integer> datasets = new ArrayList<>();
+//        ResultSet datasetQuery = executeQuery("select dataset_id from cbms.dataset where train=1");
+//        while (datasetQuery.next())
+//            datasets.add(datasetQuery.getInt("dataset_id"));
+//        return datasets;
+//    }
 
     /** When given a dataset_id, this will return an arraylist of Assets containing all of the assets in that dataset
      * the asset object will also contain a reference to all the asset attributes(sensors) and all their measurements
      *
      * @author Paul Micu
      * */
-    public ArrayList<Asset> getAssetsFromDatasetID(int datasetID) throws SQLException {
+    public ArrayList<Asset> getAssetsFromAssetTypeID(int assetTypeID) throws SQLException {
         ArrayList<Asset> assets = new ArrayList<>();
-        ResultSet assetsQuery = executeQuery("SELECT a.asset_id, a.asset_type_id, a.sn, a.location,a.description FROM asset a, dataset_asset_assoc daa WHERE a.asset_id = daa.asset_id AND daa.dataset_id=" + datasetID);
+        ResultSet assetsQuery = executeQuery("SELECT a.asset_id, a.asset_type_id, a.sn, a.location,a.description FROM asset a WHERE a.asset_type_id = " + assetTypeID);
 
         while (assetsQuery.next()) {
             Asset newAsset = new Asset();
@@ -192,7 +192,7 @@ public class Database {
         Instances data;
         double[] vals;
         String datasetName = getDatasetNameFromID(datasetID);
-        ArrayList<Asset> assets = getAssetsFromDatasetID(datasetID);
+        ArrayList<Asset> assets = getAssetsFromAssetTypeID(datasetID);
         ArrayList<String> attributeNames = getAttributesNameFromDatasetID(datasetID);
 
 

--- a/src/main/java/com/cbms/source/local/DatabaseConnection.java
+++ b/src/main/java/com/cbms/source/local/DatabaseConnection.java
@@ -8,8 +8,8 @@ public class DatabaseConnection {
     private static final String URL = "jdbc:mariadb://127.0.0.1:3306/cbms?";
     //Make sure to set the user and password to the proper values.
     //Credentials should be set to that which you are using on your local DB server.
-    private static final String USER = "root"; // todo  use username and password specific to your machine
-    private static final String PASSWORD = "1234";
+    private static final String USER = ""; // todo use username and password specific to your machine
+    private static final String PASSWORD = "";
     private static DatabaseConnection openConnection;
     private Connection conn;
 

--- a/src/main/resources/AddSystem.fxml
+++ b/src/main/resources/AddSystem.fxml
@@ -127,7 +127,7 @@
                 <Insets bottom="10.0" left="30.0" right="30.0" top="10.0"/>
             </padding>
         </Button>
-        <Button fx:id="systemMenuButton" layoutX="812.0" layoutY="645.0" mnemonicParsing="false"
+        <Button fx:id="cancelButton" layoutX="812.0" layoutY="645.0" mnemonicParsing="false"
                 stylesheets="@css/style.css" text="Cancel" textFill="#4a4a4a" AnchorPane.bottomAnchor="31.0"
                 AnchorPane.rightAnchor="43.0">
             <padding>


### PR DESCRIPTION
The database design was changed in issue #112 following some discussions with our PO. The conclusions of this discussion, that can be witnessed in the mentioned issue are the following:
- Removal of the dataset concept: we do not care to which dataset the assets, attributes or measurements belong. 
- This also means that we do not care about the difference in operational conditions that are applied to different datasets and how they could have a different impact on the RUL or measurements on the assets. 
- The only thing that will influence the RUL calculation or grouping of data (assets) is the asset type
- The classifiers (trained models) will be based on the asset type and not the dataset
- In our application, we only have 1 asset type, known as 'engine'.

With those conclusions and the update of the database design, some changes were needed to be made on the queries that extract information for the database. Whether it is to create objects or display those objects in the UI, the modifications to the queries and code affected 2 files:
- database.java (where we find all the queries on the db)
- modelcontroller.java (the main controller of our application)

Result:
Starting the application results in a longer start-up process as the preprocessing is done on 4 datasets (1 asset type) now rather than one. The application now also displays all assets (from the 4 datasets test) in the "Systems-dashboard" view as well as the "Systems-list" view instead of only the ones from dataset FD001. The rest of the application behaves normally. 

Eventual todos:
- Add SN values for assets as assets that are over ID=200 do not have SN attached to them and the display of the SN is empty (scripts). 
- Add a dropdown in the "Systems" views to choose which asset type to display assets from.
- Show the asset type name in the "Systems" view on each asset instead of the asset type ID, it would make more sense for a user.