### PR TITLE
#48 delete a system type

### DIFF
--- a/JavaFXUserInterface/src/main/java/SystemTypeController.java
+++ b/JavaFXUserInterface/src/main/java/SystemTypeController.java
@@ -87,7 +87,7 @@ public class SystemTypeController implements Initializable {
             advisory_value = assetTypeDOA.getAssetTypeBoundary(i + 1, 3);
             ok_value = assetTypeDOA.getAssetTypeBoundary(i + 1, 4);
 
-            systemtypelist.add(new SystemTypeList(systemtypelistname.get(i).getName(),systemtypelistcount.get(i),ok_value,advisory_value,caution_value,warning_value,fail_value));
+            systemtypelist.add(new SystemTypeList(systemtypelistname.get(i).getId(),systemtypelistname.get(i).getName(),systemtypelistcount.get(i),ok_value,advisory_value,caution_value,warning_value,fail_value));
         }
 
         return systemtypelist;

--- a/JavaFXUserInterface/src/main/java/SystemTypeInfoController.java
+++ b/JavaFXUserInterface/src/main/java/SystemTypeInfoController.java
@@ -1,13 +1,18 @@
 import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
+import javafx.scene.control.Alert;
 import javafx.scene.control.Button;
+import javafx.scene.control.ButtonType;
 import javafx.scene.control.TextField;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
+import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.AnchorPane;
+import local.AssetTypeDAOImpl;
 
 import java.net.URL;
 import java.text.DecimalFormat;
+import java.util.Optional;
 import java.util.ResourceBundle;
 
 public class SystemTypeInfoController implements Initializable {
@@ -70,7 +75,7 @@ public class SystemTypeInfoController implements Initializable {
     /**
      * Attaches events to elements in the scene.
      *
-     * @author Najim
+     * @author Najim, Paul
      */
     public void attachEvents() {
         // Change scenes to Systems.fxml
@@ -79,6 +84,8 @@ public class SystemTypeInfoController implements Initializable {
         systemTypeMenuBtn.setOnMouseClicked(mouseEvent -> uiUtilities.changeScene(mouseEvent, "/SystemTypeList"));
         //Attach link to infoEditBtn to go to SystemTypeEdit.fxml
         infoEditBtn.setOnMouseClicked(mouseEvent -> uiUtilities.changeScene(mouseEvent, "/SystemTypeEdit", assetType));
+        //Attach the asset type delete function
+        infoDeleteBtn.setOnMouseClicked(this::deleteDialog);
     }
 
     /**
@@ -92,5 +99,39 @@ public class SystemTypeInfoController implements Initializable {
         } else {
             systemTypeImageView.setImage(new Image("imgs/unknown_system_type.png"));
         }
+    }
+
+
+    /**
+     * Creates a dialog box that asks user if they want to delete an assetType.
+     *
+     * @param mouseEvent is an event trigger for this delete dialog
+     * @author Paul
+     */
+    private void deleteDialog(MouseEvent mouseEvent) {
+        Alert alert = new Alert(Alert.AlertType.CONFIRMATION);
+        String ALERT_TITLE = "Confirmation Dialog";
+        alert.setTitle(ALERT_TITLE);
+        String ALERT_HEADER = "Confirmation of system type deletion";
+        alert.setHeaderText(ALERT_HEADER);
+        String ALERT_CONTENT = "Are you sure you want to delete this system type? \n " +
+                "this will delete all the assets of this type";
+        alert.setContentText(ALERT_CONTENT);
+
+        Optional<ButtonType> result = alert.showAndWait();
+        if (result.isPresent() && result.get() == ButtonType.OK) {
+            deleteAssetType();
+            uiUtilities.changeScene(mouseEvent, "/SystemTypeList");
+        }
+    }
+
+    /**
+     * Send the asset ID to the Database class in order for it to be deleted.
+     *
+     * @author Paul
+     */
+    private void deleteAssetType() {
+        AssetTypeDAOImpl assetTypeDAO = new AssetTypeDAOImpl();
+        assetTypeDAO.deleteAssetTypeByID(assetType.getId());
     }
 }

--- a/JavaFXUserInterface/src/main/java/SystemTypeList.java
+++ b/JavaFXUserInterface/src/main/java/SystemTypeList.java
@@ -1,7 +1,7 @@
 import javafx.beans.property.SimpleStringProperty;
 
 public class SystemTypeList {
-    private SimpleStringProperty name;
+    private SimpleStringProperty name, id;
     private int associated_assets;
     private double value_ok,value_caution,value_advisory,value_warning,value_failed;
 
@@ -10,7 +10,8 @@ public class SystemTypeList {
         this.associated_assets = associated_assets;
     }
 
-    public SystemTypeList(String name, int associated_assets, double value_ok, double value_caution, double value_advisory, double value_warning, double value_failed) {
+    public SystemTypeList(String id,String name, int associated_assets, double value_ok, double value_caution, double value_advisory, double value_warning, double value_failed) {
+        this.id = new SimpleStringProperty(id);
         this.name = new SimpleStringProperty(name);
         this.associated_assets = associated_assets;
         this.value_ok = value_ok;
@@ -66,6 +67,18 @@ public class SystemTypeList {
 
     public SimpleStringProperty nameProperty() {
         return name;
+    }
+
+    public String getId() {
+        return id.get();
+    }
+
+    public SimpleStringProperty idProperty() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id.set(id);
     }
 
     public void setName(String name) {

--- a/JavaFXUserInterface/src/test/java/RemoveSystemTypeTest.java
+++ b/JavaFXUserInterface/src/test/java/RemoveSystemTypeTest.java
@@ -1,0 +1,34 @@
+import app.item.AssetType;
+import local.AssetTypeDAOImpl;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+
+public class RemoveSystemTypeTest {
+
+    @Test
+    public void testRemovingFunctionality(){
+        String testName = "Testing type";
+        AssetTypeDAOImpl assetTypeDAO = new AssetTypeDAOImpl();
+        AssetType assetType = new AssetType();
+        assetType.setName(testName);
+        assetType.setThresholdList(new ArrayList<>());
+
+        // adding the new asset type
+        String testID = String.valueOf(assetTypeDAO.insertAssetType(assetType));
+
+        // first assert
+        Assert.assertEquals("Checking a new asset type was added", testName, assetTypeDAO.getNameFromID(testID) );
+
+        // deleting the newly inserted asset type
+        assetTypeDAO.deleteAssetTypeByID(testID);
+
+        // second assert
+        Assert.assertFalse(assetTypeDAO.getAssetTypeList().stream()
+                .filter(s -> s.getId().equals(testID))
+                .findAny()
+                .isPresent());
+
+    }
+}

--- a/Server/src/main/java/local/AssetTypeDAO.java
+++ b/Server/src/main/java/local/AssetTypeDAO.java
@@ -5,7 +5,7 @@ import app.item.AssetType;
 import java.util.ArrayList;
 
 public interface AssetTypeDAO {
-    void insertAssetType(AssetType assetType);
+    int insertAssetType(AssetType assetType);
     ArrayList<AssetType> getAssetTypeList();
     String getNameFromID(String id);
 }

--- a/Server/src/main/java/local/AssetTypeDAOImpl.java
+++ b/Server/src/main/java/local/AssetTypeDAOImpl.java
@@ -16,7 +16,7 @@ public class AssetTypeDAOImpl extends DAO implements AssetTypeDAO {
     private static final String GET_ASSET_TYPE_NAME_FROM_ID = "SELECT name FROM asset_type where asset_type_id = ?";
     private static final String GET_ASSET_TYPE_BOUNDARY = "SELECT *  FROM asset_type_parameters WHERE parameter_name = ? AND asset_type_id = ?";
     private static final String GET_ASSET_TYPE_ID_COUNT = "SELECT asset_type_id, COUNT(*) as 'count' FROM asset WHERE archived = 0 GROUP BY asset_type_id";
-
+    private static final String DELETE_ASSET_TYPE = "DELETE FROM asset_type where asset_type_id = ?";
     /**
      * This will return an arraylist of the count for all the asset type ids from the
      * asset table
@@ -116,4 +116,12 @@ public class AssetTypeDAOImpl extends DAO implements AssetTypeDAO {
     }
 
 
+    public void deleteAssetTypeByID(String assetTypeID) {
+        try (PreparedStatement ps = getConnection().prepareStatement(DELETE_ASSET_TYPE)) {
+            ps.setString(1,assetTypeID);
+            ps.executeQuery();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
 }

--- a/Server/src/main/java/local/AssetTypeDAOImpl.java
+++ b/Server/src/main/java/local/AssetTypeDAOImpl.java
@@ -53,7 +53,7 @@ public class AssetTypeDAOImpl extends DAO implements AssetTypeDAO {
 
 
     @Override
-    public void insertAssetType(AssetType assetType) {
+    public int insertAssetType(AssetType assetType) {
         try (PreparedStatement ps = getConnection().prepareStatement(INSERT_ASSET_TYPE,
                 Statement.RETURN_GENERATED_KEYS)) {
             ps.setString(1, assetType.getName());
@@ -69,6 +69,7 @@ public class AssetTypeDAOImpl extends DAO implements AssetTypeDAO {
                             statement.executeQuery();
                         }
                     }
+                    return generatedKeys.getInt(1);
                 } else {
                     throw new SQLException("Creating threshold failed, no ID obtained.");
                 }
@@ -76,6 +77,7 @@ public class AssetTypeDAOImpl extends DAO implements AssetTypeDAO {
         } catch (SQLException e) {
             e.printStackTrace();
         }
+        return -1;
     }
 
     /**


### PR DESCRIPTION
You might need to implement the fix from : https://jeffreyeverhart.com/2017/11/04/mysql-workbench-error-code-2013-lost-connection-mysql-server-query/

This is because there are a lot of measurements and assets to delete in the background when deleting an asset type.
I had to do it for running the sql in the workbench, it might not be necessary when testing the application itself.

When confirming the deletion , it might take a little time to run the delete and go back to the main screen. This is "normal" and we will need to implement a loading screen in the future for all of these kinds of actions that require a load time

This PR resolves #48 