### PR TITLE
#247 model too large for db storage

### DIFF
--- a/Server/src/main/java/app/ModelController.java
+++ b/Server/src/main/java/app/ModelController.java
@@ -59,6 +59,9 @@ public class ModelController {
                 System.out.println("ModelController - initialize - checkAsset - start");
                 checkAssets();
                 System.out.println("ModelController - initialize - checkAsset - end");
+                System.out.println("ModelController - initialize - checkModels - start");
+                checkModels();
+                System.out.println("ModelController - initialize - checkModels - end");
             }
         }, 0, 5000);
     }

--- a/Server/src/main/java/app/item/AssetAttribute.java
+++ b/Server/src/main/java/app/item/AssetAttribute.java
@@ -17,7 +17,13 @@ public class AssetAttribute {
     private String name;
 
     public AssetAttribute() {
-        measurements = new ArrayList<>();
+        this.measurements = new ArrayList<>();
+    }
+
+    public AssetAttribute(int id, String name) {
+        this.measurements = new ArrayList<>();
+        this.id = id;
+        this.name = name;
     }
 
     public void addMeasurement(int time, double value) {


### PR DESCRIPTION
2 issues were found during the bug investigation
1 - after some unknown changes, the train model no longer works as intended
2 - the Classifier object created by the LSTM model is larger than 64k which is what the BLOB column can store

Issue 1 was fixed with rewriting the createAssetInfo() function in the AssetDAOImpl
Issue 2 was fixed in a new dump file by changing the Column type from BLOB to LONGBLOLB for the "serialized_model" column. This brings the available space from 64kb to 4gb  

this issue resolves #247  