### PR TITLE
#168 Addressing needed UI changes

### DIFF
--- a/JavaFXUserInterface/src/main/java/controllers/AddAssetTypeController.java
+++ b/JavaFXUserInterface/src/main/java/controllers/AddAssetTypeController.java
@@ -39,8 +39,6 @@ public class AddAssetTypeController implements Initializable {
     @FXML
     private TextArea assetTypeDescription;
     @FXML
-    private TextField thresholdOKValue;
-    @FXML
     private TextField thresholdAdvisoryValue;
     @FXML
     private TextField thresholdCautionValue;
@@ -86,8 +84,6 @@ public class AddAssetTypeController implements Initializable {
             }
         });
 
-
-        thresholdOKValue.setTextFormatter(new TextFormatter<>(c -> UIUtilities.checkFormat(TextConstants.ThresholdValueFormat, c)));
         thresholdAdvisoryValue.setTextFormatter(new TextFormatter<>(c -> UIUtilities.checkFormat(TextConstants.ThresholdValueFormat, c)));
         thresholdCautionValue.setTextFormatter(new TextFormatter<>(c -> UIUtilities.checkFormat(TextConstants.ThresholdValueFormat, c)));
         thresholdWarningValue.setTextFormatter(new TextFormatter<>(c -> UIUtilities.checkFormat(TextConstants.ThresholdValueFormat, c)));
@@ -108,8 +104,6 @@ public class AddAssetTypeController implements Initializable {
             } else {
                 assetType.setDescription(null);
             }
-            Double okValue = thresholdOKValue.getText().isEmpty() ? null : Double.parseDouble(thresholdOKValue.getText());
-            assetTypeParameters.add(new AssetTypeParameter(TextConstants.OK_THRESHOLD, okValue));
 
             Double advisoryValue = thresholdAdvisoryValue.getText().isEmpty() ? null : Double.parseDouble(thresholdAdvisoryValue.getText());
             assetTypeParameters.add(new AssetTypeParameter(TextConstants.ADVISORY_THRESHOLD, advisoryValue));

--- a/JavaFXUserInterface/src/main/java/controllers/AssetTypeInfoController.java
+++ b/JavaFXUserInterface/src/main/java/controllers/AssetTypeInfoController.java
@@ -131,7 +131,7 @@ public class AssetTypeInfoController implements Initializable {
 
         // Initializing Data for the threshold text fields
         ObservableList<TextField> thresholdTextFieldList = FXCollections.observableArrayList();
-        thresholdTextFieldList.addAll(thresholdOK, thresholdAdvisory, thresholdCaution, thresholdWarning, thresholdFailed);
+        thresholdTextFieldList.addAll(thresholdAdvisory, thresholdCaution, thresholdWarning, thresholdFailed);
         try {
             if (assetType.getValueAdvisory() != null && !assetType.getValueAdvisory().equalsIgnoreCase("null"))
                 thresholdAdvisory.setText(TextConstants.ThresholdValueFormat.format(Double.parseDouble(assetType.getValueAdvisory())));

--- a/JavaFXUserInterface/src/main/java/controllers/AssetTypeInfoController.java
+++ b/JavaFXUserInterface/src/main/java/controllers/AssetTypeInfoController.java
@@ -50,6 +50,8 @@ public class AssetTypeInfoController implements Initializable {
     int trainSize = 0;
     int testSize = 0;
     @FXML
+    private Text title;
+    @FXML
     private Tab modelTab;
     @FXML
     private FlowPane modelsThumbPane;
@@ -63,8 +65,6 @@ public class AssetTypeInfoController implements Initializable {
     private TextField assetTypeName;
     @FXML
     private TextArea assetTypeDesc;
-    @FXML
-    private TextField thresholdOK;
     @FXML
     private TextField thresholdAdvisory;
     @FXML
@@ -123,6 +123,7 @@ public class AssetTypeInfoController implements Initializable {
      * @author Najim, Paul
      */
     public void initData(AssetTypeList assetType) {
+        title.setText("Edit " + assetType.getName());
         this.assetType = assetType;
         this.originalAssetType = new AssetTypeList(assetType);
         assetTypeName.setText(assetType.getAssetType().getName());
@@ -130,7 +131,6 @@ public class AssetTypeInfoController implements Initializable {
         associatedModelID = modelDAO.getModelIDAssociatedWithAssetType(assetType.getId());
         associatedModelLabel.setText(modelDAO.getModelNameAssociatedWithAssetType(assetType.getId()));
         try {
-            thresholdOK.setText(TextConstants.ThresholdValueFormat.format(Double.parseDouble(assetType.getValueOk())));
             thresholdAdvisory.setText(TextConstants.ThresholdValueFormat.format(Double.parseDouble(assetType.getValueAdvisory())));
             thresholdCaution.setText(TextConstants.ThresholdValueFormat.format(Double.parseDouble(assetType.getValueCaution())));
             thresholdWarning.setText(TextConstants.ThresholdValueFormat.format(Double.parseDouble(assetType.getValueWarning())));
@@ -181,12 +181,6 @@ public class AssetTypeInfoController implements Initializable {
             if (handleTextChange(newText, originalAssetType.getDescription()))
                 assetType.getAssetType().setDescription(newText);
         });
-
-        thresholdOK.textProperty().addListener((obs, oldText, newText) -> {
-            if (handleTextChange(newText, originalAssetType.getValueOk()))
-                assetType.setValueOk(newText);
-        });
-        thresholdOK.setTextFormatter(new TextFormatter<>(c -> UIUtilities.checkFormat(TextConstants.ThresholdValueFormat, c)));
 
         thresholdAdvisory.textProperty().addListener((obs, oldText, newText) -> {
             if (handleTextChange(newText, originalAssetType.getValueAdvisory()))

--- a/JavaFXUserInterface/src/main/resources/AddAssetType.fxml
+++ b/JavaFXUserInterface/src/main/resources/AddAssetType.fxml
@@ -10,126 +10,93 @@
 <?import javafx.scene.text.Font?>
 <?import javafx.scene.text.Text?>
 
-<AnchorPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="834.0"
-            prefWidth="1194.0" xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1"
-            fx:controller="controllers.AddAssetTypeController">
-    <fx:include source="Navigation.fxml" AnchorPane.bottomAnchor="0.0" AnchorPane.topAnchor="0.0"/>
-    <AnchorPane layoutX="75.0" prefHeight="712.0" prefWidth="951.0" style="-fx-background-color: #F8F8F8;"
-                styleClass="background" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="59.0"
-                AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
-        <AnchorPane prefHeight="80.0" prefWidth="1135.0" styleClass="titleBar" AnchorPane.leftAnchor="0.0"
-                    AnchorPane.rightAnchor="0.0">
+<AnchorPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="834.0" prefWidth="1194.0" xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="controllers.AddAssetTypeController">
+    <fx:include source="Navigation.fxml" AnchorPane.bottomAnchor="0.0" AnchorPane.topAnchor="0.0" />
+    <AnchorPane layoutX="75.0" prefHeight="712.0" prefWidth="951.0" style="-fx-background-color: #F8F8F8;" styleClass="background" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="59.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+        <AnchorPane prefHeight="80.0" prefWidth="1135.0" styleClass="titleBar" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
             <children>
-                <Button fx:id="backBtn" layoutX="15.0" layoutY="17.0" mnemonicParsing="false"
-                        style="-fx-background-color: transparent;" textFill="TRANSPARENT">
+                <Button fx:id="backBtn" layoutX="15.0" layoutY="17.0" mnemonicParsing="false" style="-fx-background-color: transparent;" textFill="TRANSPARENT">
                     <graphic>
                         <ImageView fitHeight="36.0" fitWidth="36.0" pickOnBounds="true" preserveRatio="true">
                             <image>
-                                <Image url="@imgs/outline_arrow_back_black_36dp.png"/>
+                                <Image url="@imgs/outline_arrow_back_black_36dp.png" />
                             </image>
                         </ImageView>
                     </graphic>
                 </Button>
-                <Text fx:id="addAssetTitle" fill="#0c072e" layoutX="62.0" layoutY="51.0" strokeType="OUTSIDE"
-                      strokeWidth="0.0" styleClass="header" text="Add Asset Type">
+                <Text fx:id="addAssetTitle" fill="#0c072e" layoutX="62.0" layoutY="51.0" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="header" text="Add Asset Type">
                     <font>
-                        <Font name="Segoe UI Bold" size="18.0"/>
+                        <Font name="Segoe UI Bold" size="18.0" />
                     </font>
                 </Text>
             </children>
         </AnchorPane>
-        <AnchorPane layoutX="26.0" layoutY="111.0" prefHeight="615.0" prefWidth="1083.0" styleClass="panel"
-                    AnchorPane.bottomAnchor="108.0" AnchorPane.leftAnchor="26.0" AnchorPane.rightAnchor="26.0"
-                    AnchorPane.topAnchor="111.0">
-            <AnchorPane prefHeight="49.0" prefWidth="1083.0" styleClass="panelTitleBar" AnchorPane.leftAnchor="0.0"
-                        AnchorPane.rightAnchor="0.0">
+        <AnchorPane layoutX="26.0" layoutY="111.0" prefHeight="615.0" prefWidth="1083.0" styleClass="panel" AnchorPane.bottomAnchor="108.0" AnchorPane.leftAnchor="26.0" AnchorPane.rightAnchor="26.0" AnchorPane.topAnchor="111.0">
+            <AnchorPane prefHeight="49.0" prefWidth="1083.0" styleClass="panelTitleBar" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
                 <children>
-                    <Text fill="#0c072e" layoutX="26.0" layoutY="32.0" strokeType="OUTSIDE" strokeWidth="0.0"
-                          styleClass="panelTitle" text="Asset Type Information">
+                    <Text fill="#0c072e" layoutX="26.0" layoutY="32.0" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="panelTitle" text="Asset Type Information">
                         <font>
-                            <Font name="Segoe UI Bold" size="16.0"/>
+                            <Font name="Segoe UI Bold" size="16.0" />
                         </font>
                     </Text>
                 </children>
             </AnchorPane>
-            <Text layoutX="81.0" layoutY="92.0" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="formLabel"
-                  text="Asset Type Name">
+            <Text layoutX="43.0" layoutY="93.0" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="formLabel" text="Asset Type Name">
                 <font>
-                    <Font name="Segoe UI" size="14.0"/>
+                    <Font name="Segoe UI" size="14.0" />
                 </font>
             </Text>
-            <TextField fx:id="assetTypeName" layoutX="233.0" layoutY="67.0" prefHeight="40.0" prefWidth="350.0"/>
-            <Text layoutX="43.0" layoutY="133.0" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="formLabel"
-                  text="Asset Type Description">
+            <TextField fx:id="assetTypeName" layoutX="233.0" layoutY="67.0" prefHeight="40.0" prefWidth="350.0" />
+            <Text layoutX="43.0" layoutY="145.0" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="formLabel" text="Asset Type Description">
                 <font>
-                    <Font name="Segoe UI Bold" size="14.0"/>
+                    <Font name="Segoe UI Bold" size="14.0" />
                 </font>
             </Text>
-            <TextArea fx:id="assetTypeDescription" layoutX="233.0" layoutY="119.0" prefHeight="105.0"
-                      prefWidth="350.0"/>
-            <AnchorPane fx:id="inputError" layoutX="654.0" layoutY="317.0" prefHeight="318.0" prefWidth="295.0"
-                        stylesheets="@css/style.css" AnchorPane.leftAnchor="654.0">
+            <TextArea fx:id="assetTypeDescription" layoutX="233.0" layoutY="119.0" prefHeight="105.0" prefWidth="350.0" />
+            <AnchorPane fx:id="inputError" layoutX="654.0" layoutY="317.0" prefHeight="318.0" prefWidth="295.0" stylesheets="@css/style.css" AnchorPane.leftAnchor="654.0">
             </AnchorPane>
-            <Text layoutX="102.0" layoutY="261.0" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="formLabel"
-                  text="Threshold: OK">
+            <Text layoutX="43.0" layoutY="262.0" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="formLabel" text="Threshold: Advisory">
                 <font>
-                    <Font name="Segoe UI Bold" size="14.0"/>
+                    <Font name="Segoe UI Bold" size="14.0" />
                 </font>
             </Text>
-            <TextField fx:id="thresholdOKValue" layoutX="232.0" layoutY="236.0" prefHeight="40.0" prefWidth="350.0"/>
-            <Text layoutX="62.0" layoutY="313.0" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="formLabel"
-                  text="Threshold: Advisory">
+            <TextField fx:id="thresholdAdvisoryValue" layoutX="233.0" layoutY="236.0" prefHeight="40.0" prefWidth="350.0" />
+            <Text layoutX="43.0" layoutY="316.0" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="formLabel" text="Threshold: Caution">
                 <font>
-                    <Font name="Segoe UI Bold" size="14.0"/>
+                    <Font name="Segoe UI Bold" size="14.0" />
                 </font>
             </Text>
-            <TextField fx:id="thresholdAdvisoryValue" layoutX="232.0" layoutY="288.0" prefHeight="40.0"
-                       prefWidth="350.0"/>
-            <Text layoutX="71.0" layoutY="365.0" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="formLabel"
-                  text="Threshold: Caution">
+            <TextField fx:id="thresholdCautionValue" layoutX="233.0" layoutY="288.0" prefHeight="40.0" prefWidth="350.0" AnchorPane.leftAnchor="233.0" />
+            <Text layoutX="43.0" layoutY="366.0" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="formLabel" text="Threshold: Warning">
                 <font>
-                    <Font name="Segoe UI Bold" size="14.0"/>
+                    <Font name="Segoe UI Bold" size="14.0" />
                 </font>
             </Text>
-            <TextField fx:id="thresholdCautionValue" layoutX="233.0" layoutY="340.0" prefHeight="40.0" prefWidth="350.0"
-                       AnchorPane.leftAnchor="233.0"/>
-            <Text layoutX="63.0" layoutY="420.0" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="formLabel"
-                  text="Threshold: Warning">
+            <TextField fx:id="thresholdWarningValue" layoutX="233.0" layoutY="340.0" prefHeight="40.0" prefWidth="350.0" />
+            <Text layoutX="43.0" layoutY="418.0" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="formLabel" text="Threshold: Failed">
                 <font>
-                    <Font name="Segoe UI Bold" size="14.0"/>
+                    <Font name="Segoe UI Bold" size="14.0" />
                 </font>
             </Text>
-            <TextField fx:id="thresholdWarningValue" layoutX="232.0" layoutY="395.0" prefHeight="40.0"
-                       prefWidth="350.0"/>
-            <Text layoutX="81.0" layoutY="479.0" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="formLabel"
-                  text="Threshold: Failed">
-                <font>
-                    <Font name="Segoe UI Bold" size="14.0"/>
-                </font>
-            </Text>
-            <TextField fx:id="thresholdFailedValue" layoutX="232.0" layoutY="454.0" prefHeight="40.0"
-                       prefWidth="350.0"/>
+            <TextField fx:id="thresholdFailedValue" layoutX="233.0" layoutY="392.0" prefHeight="40.0" prefWidth="350.0" />
         </AnchorPane>
-        <AnchorPane layoutY="753.0" prefHeight="80.0" prefWidth="1135.0" styleClass="footerBar"
-                    AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
+        <AnchorPane layoutY="753.0" prefHeight="80.0" prefWidth="1135.0" styleClass="footerBar" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
             <children>
-                <Button fx:id="saveBtn" layoutX="799.0" layoutY="15.0" mnemonicParsing="false" styleClass="saveBtn"
-                        text="Save" textFill="WHITE" AnchorPane.bottomAnchor="15.0" AnchorPane.rightAnchor="194.0">
+                <Button fx:id="saveBtn" layoutX="799.0" layoutY="15.0" mnemonicParsing="false" styleClass="saveBtn" text="Save" textFill="WHITE" AnchorPane.bottomAnchor="15.0" AnchorPane.rightAnchor="194.0">
                     <font>
-                        <Font name="Segoe UI Semibold" size="20.0"/>
+                        <Font name="Segoe UI Semibold" size="20.0" />
                     </font>
                 </Button>
-                <Button fx:id="cancelBtn" layoutX="963.0" layoutY="14.0" mnemonicParsing="false" styleClass="cancelBtn"
-                        text="Cancel" AnchorPane.bottomAnchor="14.0" AnchorPane.rightAnchor="26.0">
+                <Button fx:id="cancelBtn" layoutX="963.0" layoutY="14.0" mnemonicParsing="false" styleClass="cancelBtn" text="Cancel" AnchorPane.bottomAnchor="14.0" AnchorPane.rightAnchor="26.0">
                     <font>
-                        <Font name="Segoe UI Semibold" size="20.0"/>
+                        <Font name="Segoe UI Semibold" size="20.0" />
                     </font>
                 </Button>
             </children>
         </AnchorPane>
     </AnchorPane>
     <stylesheets>
-        <URL value="@css/revamp/addAssetType.css"/>
-        <URL value="@css/revamp/style.css"/>
+        <URL value="@css/revamp/addAssetType.css" />
+        <URL value="@css/revamp/style.css" />
     </stylesheets>
 </AnchorPane>

--- a/JavaFXUserInterface/src/main/resources/AssetTypeInfo.fxml
+++ b/JavaFXUserInterface/src/main/resources/AssetTypeInfo.fxml
@@ -59,76 +59,65 @@
                                                 <AnchorPane layoutX="26.0" layoutY="111.0" prefHeight="615.0" prefWidth="1083.0" styleClass="panel" AnchorPane.bottomAnchor="108.0" AnchorPane.leftAnchor="26.0" AnchorPane.rightAnchor="26.0" AnchorPane.topAnchor="26.0">
                                                     <AnchorPane prefHeight="49.0" prefWidth="1083.0" styleClass="panelTitleBar" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
                                                         <children>
-                                                            <Text fill="#0c072e" layoutX="26.0" layoutY="32.0" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="panelTitle" text="Asset Information">
+                                                            <Text fill="#0c072e" layoutX="26.0" layoutY="32.0" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="panelTitle" text="Asset Type Information">
                                                                 <font>
                                                                     <Font name="Segoe UI Bold" size="16.0" />
                                                                 </font>
                                                             </Text>
                                                         </children>
                                                     </AnchorPane>
-                                                    <Text layoutX="81.0" layoutY="92.0" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="formLabel" text="Asset Type Name">
+                                                    <Text layoutX="43.0" layoutY="93.0" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="formLabel" text="Asset Type Name">
                                                         <font>
                                                             <Font name="Segoe UI" size="14.0" />
                                                         </font>
                                                     </Text>
                                                     <TextField fx:id="assetTypeName" layoutX="233.0" layoutY="67.0" prefHeight="40.0" prefWidth="350.0" />
-                                                    <Text layoutX="43.0" layoutY="133.0" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="formLabel" text="Asset Type Description">
+                                                    <Text layoutX="43.0" layoutY="145.0" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="formLabel" text="Asset Type Description">
                                                         <font>
                                                             <Font name="Segoe UI Bold" size="14.0" />
                                                         </font>
                                                     </Text>
                                                     <TextArea fx:id="assetTypeDesc" layoutX="233.0" layoutY="119.0" prefHeight="105.0" prefWidth="350.0" />
-                                                    <Text layoutX="49.0" layoutY="260.0" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="formLabel" text="Associated RUL Model">
+                                                    <Text layoutX="43.0" layoutY="262.0" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="formLabel" text="Associated RUL Model">
                                                         <font>
                                                             <Font name="Segoe UI Bold" size="14.0" />
                                                         </font>
                                                     </Text>
-                                                    <Label fx:id="associatedModelLabel" layoutX="234.0" layoutY="245.0" prefHeight="18.0" prefWidth="349.0" styleClass="formLabel" text="Associated Model Name" textFill="#3a3a3a">
+                                                    <Label fx:id="associatedModelLabel" layoutX="233.0" layoutY="247.0" prefHeight="18.0" prefWidth="349.0" styleClass="formLabel" text="Associated Model Name" textFill="#3a3a3a">
                                                         <font>
                                                             <Font name="Segoe UI" size="14.0" />
                                                         </font>
                                                     </Label>
                                                     <AnchorPane fx:id="inputError" layoutX="654.0" layoutY="317.0" prefHeight="318.0" prefWidth="295.0" stylesheets="@css/style.css" AnchorPane.leftAnchor="654.0">
                                                     </AnchorPane>
-                                                    <Text layoutX="103.0" layoutY="309.0" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="formLabel" text="Threshold: OK">
+                                                    <Text layoutX="43.0" layoutY="314.0" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="formLabel" text="Threshold: Advisory">
                                                         <font>
                                                             <Font name="Segoe UI Bold" size="14.0" />
                                                         </font>
                                                     </Text>
-                                                    <TextField fx:id="thresholdOK" layoutX="233.0" layoutY="284.0" prefHeight="40.0" prefWidth="350.0" />
-                                                    <Text layoutX="63.0" layoutY="361.0" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="formLabel" text="Threshold: Advisory">
+                                                    <TextField fx:id="thresholdAdvisory" layoutX="233.0" layoutY="288.0" prefHeight="40.0" prefWidth="350.0" />
+                                                    <Text layoutX="43.0" layoutY="366.0" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="formLabel" text="Threshold: Caution">
                                                         <font>
                                                             <Font name="Segoe UI Bold" size="14.0" />
                                                         </font>
                                                     </Text>
-                                                    <TextField fx:id="thresholdAdvisory" layoutX="233.0" layoutY="336.0" prefHeight="40.0" prefWidth="350.0" />
-                                                    <Text layoutX="72.0" layoutY="413.0" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="formLabel" text="Threshold: Caution">
+                                                    <TextField fx:id="thresholdCaution" layoutX="233.0" layoutY="340.0" prefHeight="40.0" prefWidth="350.0" AnchorPane.leftAnchor="233.0" />
+                                                    <Text layoutX="43.0" layoutY="418.0" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="formLabel" text="Threshold: Warning">
                                                         <font>
                                                             <Font name="Segoe UI Bold" size="14.0" />
                                                         </font>
                                                     </Text>
-                                                    <TextField fx:id="thresholdCaution" layoutX="233.0" layoutY="388.0" prefHeight="40.0" prefWidth="350.0" AnchorPane.leftAnchor="233.0" />
-                                                    <Text layoutX="64.0" layoutY="468.0" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="formLabel" text="Threshold: Warning">
+                                                    <TextField fx:id="thresholdWarning" layoutX="233.0" layoutY="392.0" prefHeight="40.0" prefWidth="350.0" />
+                                                    <Text layoutX="43.0" layoutY="470.0" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="formLabel" text="Threshold: Failed">
                                                         <font>
                                                             <Font name="Segoe UI Bold" size="14.0" />
                                                         </font>
                                                     </Text>
-                                                    <TextField fx:id="thresholdWarning" layoutX="233.0" layoutY="443.0" prefHeight="40.0" prefWidth="350.0" />
-                                                    <Text layoutX="82.0" layoutY="527.0" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="formLabel" text="Threshold: Failed">
-                                                        <font>
-                                                            <Font name="Segoe UI Bold" size="14.0" />
-                                                        </font>
-                                                    </Text>
-                                                    <TextField fx:id="thresholdFailed" layoutX="233.0" layoutY="502.0" prefHeight="40.0" prefWidth="350.0" />
+                                                    <TextField fx:id="thresholdFailed" layoutX="233.0" layoutY="444.0" prefHeight="40.0" prefWidth="350.0" />
                                                 </AnchorPane>
                                                 <AnchorPane prefHeight="80.0" prefWidth="1135.0" styleClass="footerBar" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
                                                     <children>
-                                                        <Button fx:id="infoSaveBtn" layoutX="799.0" layoutY="15.0" mnemonicParsing="false" styleClass="saveBtn" text="Save" textFill="WHITE" AnchorPane.bottomAnchor="15.0" AnchorPane.rightAnchor="194.0">
-                                                            <font>
-                                                                <Font name="Segoe UI Semibold" size="20.0" />
-                                                            </font>
-                                                        </Button>
-                                                        <Button fx:id="cancelBtn" layoutX="963.0" layoutY="14.0" mnemonicParsing="false" styleClass="cancelBtn" text="Cancel" AnchorPane.bottomAnchor="14.0" AnchorPane.rightAnchor="26.0">
+                                                        <Button fx:id="infoSaveBtn" layoutX="963.0" layoutY="15.0" mnemonicParsing="false" styleClass="saveBtn" text="Save" textFill="WHITE" AnchorPane.bottomAnchor="15.0" AnchorPane.rightAnchor="26.0">
                                                             <font>
                                                                 <Font name="Segoe UI Semibold" size="20.0" />
                                                             </font>

--- a/JavaFXUserInterface/src/main/resources/css/revamp/addAssetType.css
+++ b/JavaFXUserInterface/src/main/resources/css/revamp/addAssetType.css
@@ -48,9 +48,7 @@
     -fx-pref-width: 142px;
     -fx-pref-height: 40px;
     -fx-border-radius: 2px;
-    -fx-border-color: #3A3A3A;
-    -fx-border-width: 1px;
-    -fx-background-color: #FFFFFF;
+    -fx-background-color: #d5d7dd;
     -fx-font-family: "Segoe UI Semibold";
     -fx-font-size: 20px;
     -fx-fill: #3A3A3A;


### PR DESCRIPTION
Addressing UI changes for Asset Types

- Removed the cancel button on the Edit Asset Type Screen
- Title of the Edit Asset Type screen now displays "Edit [Name of Asset Type]"
- "Asset Information" changed to "Asset Type Information" on the edit screen
- All labels on the edit and add asset type screen are equally aligned now
- OK threshold labels and textfields are deleted
- Cancel button on the Add Asset type screen is now grey

This resolves #168 